### PR TITLE
Use authors field in META instead of author

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "name" : "Inline::Scheme::Gambit",
     "license" : "Artistic-2.0",
     "version" : "0.01",
-    "author" : "github:zhouzhen1",
+    "authors" : [ "github:zhouzhen1" ],
     "description" : "Embedded Gambit-C for Perl 6",
     "depends" : [ "LibraryMake" ],
     "provides" : {


### PR DESCRIPTION
This is checked by Test::Meta: https://modules.raku.org/dist/Test::META:cpan:JSTOWE/lib/Test/META.pm#L47

See https://github.com/Raku/ecosystem/pull/567 for reference